### PR TITLE
Add Octave compatibility functions

### DIFF
--- a/Utility/combinations.m
+++ b/Utility/combinations.m
@@ -1,0 +1,29 @@
+function T = combinations(varargin)
+%COMBINATIONS Generate table of all combinations of input vectors.
+%   T = combinations(v1,v2,...) returns a table with columns Var1, Var2, ...
+%   containing every possible combination of the elements of the input
+%   vectors.
+%
+%   Example:
+%       T = combinations([0 1],[2 3]);
+%
+%   This function replicates the behaviour of MATLAB's combinations
+%   function which may not be available in Octave.
+
+n = nargin;
+if n == 0
+    T = struct('Variables', []);
+    return;
+end
+
+% Use ndgrid to generate the Cartesian product
+[grids{1:n}] = ndgrid(varargin{:});
+numComb = numel(grids{1});
+vars = zeros(numComb, n);
+for k = 1:n
+    vars(:, k) = grids{k}(:);
+end
+
+% Return a struct mimicking the MATLAB table output
+T = struct('Variables', vars);
+end

--- a/Utility/updateCirParams.m
+++ b/Utility/updateCirParams.m
@@ -5,7 +5,9 @@ function updateCirParams(filename,params)
 %Richard Moore
 %2025-07-13
 
-S = readlines(filename);
+% Octave does not provide readlines or writelines. Use fileread instead.
+S = strsplit(fileread(filename), {'\r','\n'})';
+S = S(~cellfun('isempty',S));
 %k = 1;
 k = 2;
 
@@ -19,4 +21,8 @@ while ~isempty(strfind(S{k},'.param'))
     k = k + 1;
 end
 
-writelines(S,filename);
+fid = fopen(filename, 'w');
+for lineIdx = 1:numel(S)
+    fprintf(fid, '%s\n', S{lineIdx});
+end
+fclose(fid);


### PR DESCRIPTION
## Summary
- add missing `combinations` helper
- use `fileread`/`fopen` in `updateCirParams.m` for Octave

## Testing
- `octave --eval "addpath('Utility'); addpath('AnalysisScripts'); compareRatParams" | head -n 20` *(fails: Undefined parameter [p1_pos])*

------
https://chatgpt.com/codex/tasks/task_e_68829d0999808325b22356583d05e8aa