### PR TITLE
Add init_path.m for Octave path setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,14 @@ Guitar pedal netlists for ngspice modeling &amp; simulation
 
 A MATLAB Live Script facilitates pot/switch position adjustments and output plotting:
 ![SPICEyPedalsMlxScreenshot.png](https://github.com/thecowgoesmoo/SPICEyPedals/blob/5427526bb07315d15c31d103281cbcd158f9f4ae/SPICEyPedalsMlxScreenshot.png)
+
+## Getting Started
+
+Before using any of the MATLAB or Octave utilities in this repository, run the
+`init_path.m` script from the repository root. This will add all of the
+SPICEyPedals subfolders to your MATLAB/Octave path so functions and scripts can
+be located:
+
+```matlab
+init_path
+```

--- a/init_path.m
+++ b/init_path.m
@@ -1,0 +1,4 @@
+% init_path.m
+%% Adds the SPICEyPedals repository and subfolders to the Octave/MATLAB path.
+
+addpath(genpath(pwd));


### PR DESCRIPTION
## Summary
- add a helper script `init_path.m` that adds all repository folders to the Octave/MATLAB path
- document running `init_path.m` before using repo scripts

## Testing
- `git status --short`
- `apt-get install -y octave` *(fails: cannot configure ca-certificates-java)*

------
https://chatgpt.com/codex/tasks/task_e_6882a8e606d083258fef9d7faef096b0