### PR TITLE
Regenerate netlists after fixing default substitution

### DIFF
--- a/PedalNetlists/Boss_Super_Overdrive_SD-1.cir
+++ b/PedalNetlists/Boss_Super_Overdrive_SD-1.cir
@@ -2,6 +2,7 @@
 .param P_Tone = 1
 .param P_Level = 0.5
 .include "/workspace/SPICEyPedals/tools/../PartModels/MicroCap-LIBRARY-for-ngspice/On_Semi.lib"
+.include "/workspace/SPICEyPedals/tools/../PartModels/modelos_subckt/ti/tl072.mod"
 * generated from Boss Super Overdrive SD-1.schx
 VCC VCC 0 DC 9
 VIN IN 0 SIN(0 50m 500)

--- a/PedalNetlists/Bridge_Rectifier.cir
+++ b/PedalNetlists/Bridge_Rectifier.cir
@@ -1,12 +1,13 @@
+.include "/workspace/SPICEyPedals/tools/../PartModels/modelos_subckt/Diode_BJT_FET/GenSemi/GSdevices.lb5"
 * generated from Bridge Rectifier.schx
 VCC VCC 0 DC 9
 VIN IN 0 SIN(0 50m 500)
 RR2 IN N2 100
 RS1 0 N7 8
-DD1 N5 0 D
-DD2 N10 N11 D
-DD3 N5 N9 D
-DD4 N7 N8 D
+DD1 N5 0 d1n4148ws ; default 1N4148
+DD2 N10 N11 d1n4148ws ; default 1N4148
+DD3 N5 N9 d1n4148ws ; default 1N4148
+DD4 N7 N8 d1n4148ws ; default 1N4148
 .tran 2u 100m 80m
 .op
 .control

--- a/PedalNetlists/Common_Emitter_Transistor_Amplifier.cir
+++ b/PedalNetlists/Common_Emitter_Transistor_Amplifier.cir
@@ -1,3 +1,4 @@
+.include "/workspace/SPICEyPedals/tools/../PartModels/MicroCap-LIBRARY-for-ngspice/On_Semi.lib"
 * generated from Common Emitter Transistor Amplifier.schx
 VCC VCC 0 DC 9
 VIN IN 0 SIN(0 50m 500)
@@ -10,7 +11,7 @@ RRf N3 N6 470k
 CCf N3 N6 250p
 RO1 0 N9 8
 RR1 N9 0 100k
-QQ1 N3 N6 N11 Q
+QQ1 N3 N6 N11 Q2N2222 ; default 2N2222
 .tran 2u 100m 80m
 .op
 .control

--- a/PedalNetlists/Ibanez_Tube_Screamer_TS-9.cir
+++ b/PedalNetlists/Ibanez_Tube_Screamer_TS-9.cir
@@ -2,6 +2,7 @@
 .param P_Tone = 1
 .param P_Level = 0.5
 .include "/workspace/SPICEyPedals/tools/../PartModels/modelos_subckt/Diode_BJT_FET/GenSemi/GSdevices.lb5"
+.include "/workspace/SPICEyPedals/tools/../PartModels/modelos_subckt/ti/tl072.mod"
 * generated from Ibanez Tube Screamer TS-9.schx
 VCC VCC 0 DC 9
 VIN IN 0 SIN(0 50m 500)

--- a/PedalNetlists/MXR_Phase_90.cir
+++ b/PedalNetlists/MXR_Phase_90.cir
@@ -1,6 +1,7 @@
 .param P_Trimmer = 0.5
 .param P_Speed = 0.5
 .include "/workspace/SPICEyPedals/tools/../PartModels/MicroCap-LIBRARY-for-ngspice/On_Semi.lib"
+.include "/workspace/SPICEyPedals/tools/../PartModels/modelos_subckt/ti/tl072.mod"
 * generated from MXR Phase 90.schx
 VCC VCC 0 DC 9
 VIN IN 0 SIN(0 50m 500)

--- a/PedalNetlists/Marshall_Blues_Breaker.cir
+++ b/PedalNetlists/Marshall_Blues_Breaker.cir
@@ -2,6 +2,7 @@
 .param P_Tone = 0.8
 .param P_Level = 0.5
 .include "/workspace/SPICEyPedals/tools/../PartModels/modelos_subckt/Diode_BJT_FET/GenSemi/GSdevices.lb5"
+.include "/workspace/SPICEyPedals/tools/../PartModels/modelos_subckt/ti/tl072.mod"
 * generated from Marshall Blues Breaker.schx
 VCC VCC 0 DC 9
 VIN IN 0 SIN(0 50m 500)

--- a/PedalNetlists/Op-Amp_Model.cir
+++ b/PedalNetlists/Op-Amp_Model.cir
@@ -1,10 +1,11 @@
+.include "/workspace/SPICEyPedals/tools/../PartModels/modelos_subckt/Diode_BJT_FET/GenSemi/GSdevices.lb5"
 * generated from Op-Amp Model.schx
 VCC VCC 0 DC 9
 VIN IN 0 SIN(0 50m 500)
 RR1 N2 0 100
 RR2 N6 N7 10k
-DD1 N1 N10 D
-DD2 N1 N11 D
+DD1 N1 N10 d1n4148ws ; default 1N4148
+DD2 N1 N11 d1n4148ws ; default 1N4148
 RS1 N7 0 8
 VV6 N9 N10 2
 VV7 N11 N12 2

--- a/tools/schx_to_netlist.py
+++ b/tools/schx_to_netlist.py
@@ -115,6 +115,16 @@ def default_part_for(stype: str, attrs: dict) -> str | None:
         return DEFAULT_PARTS['jfet_p'] if typ.startswith('P') else DEFAULT_PARTS['jfet_n']
     return None
 
+GENERIC_PARTS = {
+    '', 'D', 'Q', 'NPN', 'PNP', 'FET', 'JFET', 'MOSFET', 'NMOS', 'PMOS',
+    'MOS', 'OPAMP', 'OP-AMP', 'OP_AMP'
+}
+
+def is_unspecified(part: str | None) -> bool:
+    if not part:
+        return True
+    return part.upper() in GENERIC_PARTS
+
 class UnionFind:
     def __init__(self):
         self.parent = {}
@@ -222,7 +232,7 @@ def process_file(path):
         if model_info:
             includes.add(f".include \"{model_info[0]}\"")
             model_name = model_info[1]
-        else:
+        elif is_unspecified(specified):
             default = default_part_for(stype, attrs)
             if default:
                 info = find_model(default)
@@ -231,8 +241,7 @@ def process_file(path):
                     model_name = info[1]
                 else:
                     model_name = default
-                if not specified:
-                    comment = f" ; default {default}"
+                comment = f" ; default {default}"
 
         if 'Potentiometer' in stype and len(nets) == 3:
             pname = f"P_{name}"


### PR DESCRIPTION
## Summary
- avoid replacing specified part numbers when default models used
- connect default models only for generic/unspecified parts
- regenerate affected netlists with original part numbers restored

## Testing
- `python3 tools/schx_to_netlist.py`

------
https://chatgpt.com/codex/tasks/task_e_6885aac56cfc8325a17d37431db15131