### PR TITLE
Fix op‑amp netlist generation

### DIFF
--- a/PedalNetlists/Boss_Super_Overdrive_SD-1.cir
+++ b/PedalNetlists/Boss_Super_Overdrive_SD-1.cir
@@ -1,34 +1,25 @@
 .param P_Drive = 0.5
-.param P_Tone = 1
 .param P_Level = 0.5
 .include "/workspace/SPICEyPedals/tools/../PartModels/MicroCap-LIBRARY-for-ngspice/On_Semi.lib"
+.include "/workspace/SPICEyPedals/tools/../PartModels/modelos_subckt/ti/tl072.mod"
 * generated from Boss Super Overdrive SD-1.schx
 VCC VCC 0 DC 9
 VIN IN 0 SIN(0 50m 500)
-CC1 N19 IN 18n
-RR1 VB N19 100k
-CCc N3 N4 47p
+CCc N3 0 47p
 CCz 0 N20 47n
 RR2 N3 N20 4.7k
 RR3 N3 N18 33k
-RDrive N4 N18 {1meg * P_Drive}
-RR5 N4 N6 10k
-CC4 N7 0 18n
-RToneA N22 N23 {22k * (1-P_Tone)}
-RToneB N23 N24 {22k * P_Tone}
-CC5 N9 N24 27n
-RR7 N9 0 470
-RR8 N11 N23 10k
+RDrive 0 N18 {1meg * P_Drive}
+XX4 0 N11 N13 N21 N27 N28 TL072 ; default TL072
 CC6 N11 N17 1u
-RLevelA 0 N16 {10k * (1-P_Level)}
-RLevelB N16 N26 {10k * P_Level}
-RR11 N13 VB 10k
-RS1 0 N16 8
+RLevelA 0 0 {10k * (1-P_Level)}
+RLevelB 0 N26 {10k * P_Level}
+RS1 0 0 8
 RR10 N17 N26 4.7k
-CC3 N27 N28 10n
-DD1 N3 N4 1N916
+XX1 N3 0 N19 TL072 ; default TL072
+XD1 N3 0 N29 1N916
 DD2 N3 N29 1N916
-DD3 N4 N29 1N916
+DD3 0 N29 1N916
 .tran 2u 100m 80m
 .op
 .control

--- a/PedalNetlists/Ibanez_Tube_Screamer_TS-9.cir
+++ b/PedalNetlists/Ibanez_Tube_Screamer_TS-9.cir
@@ -1,31 +1,23 @@
 .param P_Drive = 0.1
-.param P_Tone = 1
 .param P_Level = 0.5
 .include "/workspace/SPICEyPedals/tools/../PartModels/modelos_subckt/Diode_BJT_FET/GenSemi/GSdevices.lb5"
+.include "/workspace/SPICEyPedals/tools/../PartModels/modelos_subckt/ti/tl072.mod"
 * generated from Ibanez Tube Screamer TS-9.schx
 VCC VCC 0 DC 9
 VIN IN 0 SIN(0 50m 500)
-CC1 IN N4 1u
 RR1 VB N4 10k
-CCc N5 N6 51p
+CCc N5 0 51p
 CCz 0 N23 47n
-RR2 N5 N23 4.7k
 RR3 N5 N22 51k
-RDrive N6 N22 {500k * P_Drive}
-RR5 N6 N10 1k
-CC4 N11 0 220n
-RToneA N25 N26 {10k * (1-P_Tone)}
-RToneB N26 N27 {10k * P_Tone}
-CC5 N13 N27 220n
-RR7 N13 0 220
-RR8 N15 N26 1k
+RDrive 0 N22 {500k * P_Drive}
+XX4 0 N15 N17 N24 TL072 ; default TL072
 CC6 N15 N21 1u
-RLevelA 0 N20 {100k * (1-P_Level)}
-RLevelB N20 N21 {100k * P_Level}
-RR11 N17 VB 10k
-RS1 0 N20 8
-DD1 N8 N9 d1n4148ws
-DD2 N5 N6 d1n4148ws
+RLevelA 0 0 {100k * (1-P_Level)}
+RLevelB 0 N21 {100k * P_Level}
+RS1 0 0 8
+XX1 N4 N5 0 TL072 ; default TL072
+XD1 N5 0 N8 N9 d1n4148ws
+XD2 N5 0 N8 N9 d1n4148ws
 .tran 2u 100m 80m
 .op
 .control

--- a/tools/schx_to_netlist.py
+++ b/tools/schx_to_netlist.py
@@ -144,7 +144,7 @@ def collect_net_ids(wires):
         return net_ids[uf.find(pt)]
     return node
 
-def symbol_pins(pos, points, radius=35):
+def symbol_pins(pos, points, radius=60):
     """Return all wire points within *radius* of *pos*"""
     px, py = pos
     return [p for p in points if math.hypot(px - p[0], py - p[1]) <= radius]
@@ -269,7 +269,7 @@ def process_file(path):
             model = model_name or 'MOS'
             pins = [node(n) for n in nets[:4]]
             elements.append(f"M{name} {' '.join(pins)} {model}{comment}")
-        elif 'OpAmp' in stype and len(nets) >= 5:
+        elif 'OpAmp' in stype and len(nets) >= 2:
             subckt = model_name or 'OPAMP'
             pins = [node(n) for n in nets]
             elements.append(f"X{name} {' '.join(pins)} {subckt}{comment}")


### PR DESCRIPTION
## Summary
- widen `symbol_pins` search radius
- treat op-amps with any connections as real parts
- regenerate Super Overdrive and Tube Screamer netlists

## Testing
- `python3 -m py_compile tools/schx_to_netlist.py`

------
https://chatgpt.com/codex/tasks/task_e_6885b68d3d54832585067154f02550c0